### PR TITLE
MAINT: simplify regex minus

### DIFF
--- a/flake8_array_spacing/__init__.py
+++ b/flake8_array_spacing/__init__.py
@@ -11,8 +11,8 @@ __version__ = '0.3.dev0'
 # (no pairing within, or checking that i/j are attached to a number, etc.)
 _FMT = dict(
     VARIABLE=r'[_a-z]+[_a-z0-9]*',
-    OPERATORS=r'[+\-*\/^\|&]',
-    SEPARATORS=r'[+\-*\/^\|& ,\[\]()]',
+    OPERATORS=r'[-+*\/^\|&]',
+    SEPARATORS=r'[-+*\/^\|& ,\[\]()]',
     NUMERICAL=r"""
 (
 [0-9.]+(e[+-]?[0-9.]+)?j?|


### PR DESCRIPTION
* we can avoid escaping `-` in character classes
by placing it at the start of the class; this prevents
its augmentation to a range metacharacter and makes
the expression a little easier to read